### PR TITLE
TODO描画に必要なAPIと他の諸々の機能を修正

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -18,16 +18,23 @@ func ReadCSV(fp *os.File) ([]Todo, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 		items := strings.Split(line, ",")
+        arch := false
 
 		no, err := strconv.Atoi(strings.TrimSpace(items[0]))
+
 		if err != nil {
 			return nil, err
 		}
+
+        if strings.TrimSpace(items[3]) == "true" {
+            arch = true
+        }
 
 		todo := &Todo{
 			no:    no,
 			label: strings.TrimSpace(items[1]),
 			title: strings.TrimSpace(items[2]),
+            isArchived: arch,
 		}
 		todos = append(todos, (*todo))
 	}

--- a/csv.go
+++ b/csv.go
@@ -7,36 +7,41 @@ import (
 	"strings"
 )
 
-func ReadCSV(fp *os.File) ([]Todo, error) {
+func ReadCSV(fp *os.File) ([]Todo, []Todo, error) {
 	scanner := bufio.NewScanner(fp)
 	if err := scanner.Err(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	todos := make([]Todo, 0, 100)
+	archs := make([]Todo, 0, 100)
 
 	for scanner.Scan() {
 		line := scanner.Text()
 		items := strings.Split(line, ",")
-        arch := false
+		arch := false
 
 		no, err := strconv.Atoi(strings.TrimSpace(items[0]))
 
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
-        if strings.TrimSpace(items[3]) == "true" {
-            arch = true
-        }
+		if strings.TrimSpace(items[3]) == "true" {
+			arch = true
+		}
 
 		todo := &Todo{
-			no:    no,
-			label: strings.TrimSpace(items[1]),
-			title: strings.TrimSpace(items[2]),
-            isArchived: arch,
+			no:         no,
+			label:      strings.TrimSpace(items[1]),
+			title:      strings.TrimSpace(items[2]),
+			isArchived: arch,
 		}
-		todos = append(todos, (*todo))
+		if arch {
+			todos = append(todos, (*todo))
+		} else {
+			archs = append(archs, (*todo))
+		}
 	}
-	return todos, nil
+	return todos, archs, nil
 }

--- a/todo.go
+++ b/todo.go
@@ -2,10 +2,12 @@ package yalzo
 
 import (
 	"os"
+	"strconv"
 )
 
 type TodoList struct {
-	list   []Todo
+	todos  []Todo
+	archs  []Todo
 	labels []string
 }
 
@@ -16,43 +18,100 @@ type Todo struct {
 	no         int
 }
 
+type Tab int
+
+const (
+	TODO Tab = iota
+	ARCHIVE
+)
+
 func NewTodoList(fp *os.File, ls []string) *TodoList {
-	l, err := ReadCSV(fp)
+	l, as, err := ReadCSV(fp)
 	if err != nil {
 		panic(err)
 	}
+
 	return &TodoList{
-		list:   l,
+		todos:  l,
+		archs:  as,
 		labels: ls,
 	}
 }
 
+func (tl *TodoList) GetTodos(width int) []string {
+	lines := make([]string, 0, 100)
+	for i := 0; i < len(tl.todos); i++ {
+		lines = append(lines, tl.todos[i].tolimitStr(width))
+	}
+	return lines
+}
+
+func (tl *TodoList) GetArchives(width int) []string {
+	lines := make([]string, 0, 100)
+	for i := 0; i < len(tl.archs); i++ {
+		lines = append(lines, tl.archs[i].tolimitStr(width))
+	}
+	return lines
+}
+
 func (tl *TodoList) ChangeLabelName(i int, l string) {
-	(*tl).list[i].label = l
+	(*tl).todos[i].label = l
 }
 
 func (tl *TodoList) Delete(n int) {
-	for i := n; i < len((*tl).list); i++ {
-		(*tl).list[i].setNumber(i)
+	for i := n; i < len((*tl).todos); i++ {
+		(*tl).todos[i].setNumber(i)
 	}
-	tl.list = append(tl.list[:n], tl.list[n+1:]...)
+	tl.todos = append(tl.todos[:n], tl.todos[n+1:]...)
 }
 
 func (tl *TodoList) AddTodo(l string, t string) {
-	tl.list = append(tl.list, Todo{
-		no:    len(tl.list),
+	tl.todos = append(tl.todos, Todo{
+		no:    len(tl.todos),
 		label: l,
 		title: t,
 	})
 }
 
-func (tl *TodoList) Exchange(i1 int, i2 int) {
-	(*tl).list[i2].setNumber(i1 + 1)
-	(*tl).list[i1].setNumber(i2 + 1)
+func (tl *TodoList) MoveArchive(n int) {
+	length := len(tl.todos)
+	tl.todos[n].isArchived = true
+	tl.todos[n].setNumber(length)
+	tl.archs = append(tl.archs, tl.todos[n])
+	for i := n + 1; i < len(tl.todos); i++ {
+		tl.todos[i].setNumber(i - 1)
+	}
+	tl.todos = append(tl.todos[:n], tl.todos[n+1:]...)
+}
 
-    (*tl).list[i2], (*tl).list[i1] = (*tl).list[i1], (*tl).list[i2] 
+func (tl *TodoList) MoveTodo(n int) {
+	length := len(tl.todos)
+	tl.archs[n].isArchived = false
+	tl.archs[n].setNumber(length)
+	tl.todos = append(tl.todos, tl.archs[n])
+	for i := n + 1; i < length; i++ {
+		tl.todos[i].setNumber(i - 1)
+	}
+	tl.archs = append(tl.archs[:n], tl.archs[n+1:]...)
+}
+
+func (tl *TodoList) Exchange(i1 int, i2 int) {
+	(*tl).todos[i2].setNumber(i1 + 1)
+	(*tl).todos[i1].setNumber(i2 + 1)
+
+	(*tl).todos[i2], (*tl).todos[i1] = (*tl).todos[i1], (*tl).todos[i2]
 }
 
 func (t *Todo) setNumber(n int) {
 	(*t).no = n
+}
+
+func (t *Todo) tolimitStr(limit int) string {
+	str := strconv.Itoa(t.no) + t.label + t.title
+	length := len(str)
+	if length > limit {
+		return str[:limit]
+	} else {
+		return str
+	}
 }

--- a/todo.go
+++ b/todo.go
@@ -54,6 +54,24 @@ func (tl *TodoList) GetArchives(width int) []string {
 	return lines
 }
 
+func (tl *TodoList) GetLabels() []string {
+	for i := 0; i < len(tl.todos); i++ {
+		label := tl.todos[i].label
+		if !(tl.existLabel(label)) {
+			tl.labels = append(tl.labels, label)
+		}
+	}
+
+	for i := 0; i < len(tl.archs); i++ {
+		label := tl.archs[i].label
+		if !(tl.existLabel(label)) {
+			tl.labels = append(tl.labels, label)
+		}
+	}
+
+	return tl.labels
+}
+
 func (tl *TodoList) ChangeTitle(i int, t string, state Type) {
 	if state == TODO {
 		(*tl).todos[i].title = t
@@ -116,6 +134,15 @@ func (tl *TodoList) Exchange(i1 int, i2 int) {
 
 func (t *Todo) setNumber(n int) {
 	(*t).no = n
+}
+
+func (tl *TodoList) existLabel(l string) bool {
+	for i := 0; i < len(tl.labels); i++ {
+		if tl.labels[i] == l {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *Todo) tolimitStr(limit int) string {

--- a/todo.go
+++ b/todo.go
@@ -54,8 +54,20 @@ func (tl *TodoList) GetArchives(width int) []string {
 	return lines
 }
 
-func (tl *TodoList) ChangeLabelName(i int, l string) {
-	(*tl).todos[i].label = l
+func (tl *TodoList) ChangeTitle(i int, t string, state Type) {
+	if state == TODO {
+		(*tl).todos[i].title = t
+	} else {
+		(*tl).archs[i].title = t
+	}
+}
+
+func (tl *TodoList) ChangeLabelName(i int, l string, state Type) {
+	if state == TODO {
+		(*tl).todos[i].label = l
+	} else {
+		(*tl).archs[i].label = l
+	}
 }
 
 func (tl *TodoList) Delete(n int) {

--- a/todo.go
+++ b/todo.go
@@ -38,18 +38,11 @@ func NewTodoList(fp *os.File, ls []string) *TodoList {
 	}
 }
 
-func (tl *TodoList) GetTodos(width int) []string {
+func (tl *TodoList) GetList(width int, tab Tab) []string {
 	lines := make([]string, 0, 100)
-	for i := 0; i < len(tl.todos); i++ {
-		lines = append(lines, tl.todos[i].tolimitStr(width))
-	}
-	return lines
-}
-
-func (tl *TodoList) GetArchives(width int) []string {
-	lines := make([]string, 0, 100)
-	for i := 0; i < len(tl.archs); i++ {
-		lines = append(lines, tl.archs[i].tolimitStr(width))
+	lists := tl.getListInTab(tab)
+	for i := 0; i < len(lists); i++ {
+		lines = append(lines, lists[i].tolimitStr(width))
 	}
 	return lines
 }
@@ -72,18 +65,30 @@ func (tl *TodoList) GetLabels() []string {
 	return tl.labels
 }
 
-func (tl *TodoList) ChangeTitle(i int, t string, state Type) {
-	if state == TODO {
+func (tl *TodoList) GetTabName(tab Tab) string {
+	switch tab {
+	case TODO:
+		return "Todo"
+	case ARCHIVE:
+		return "Archive"
+	}
+	return "Unknown"
+}
+
+func (tl *TodoList) ChangeTitle(i int, t string, tab Tab) {
+	switch tab {
+	case TODO:
 		(*tl).todos[i].title = t
-	} else {
+	case ARCHIVE:
 		(*tl).archs[i].title = t
 	}
 }
 
-func (tl *TodoList) ChangeLabelName(i int, l string, state Type) {
-	if state == TODO {
+func (tl *TodoList) ChangeLabelName(i int, l string, tab Tab) {
+	switch tab {
+	case TODO:
 		(*tl).todos[i].label = l
-	} else {
+	case ARCHIVE:
 		(*tl).archs[i].label = l
 	}
 }
@@ -143,6 +148,16 @@ func (tl *TodoList) existLabel(l string) bool {
 		}
 	}
 	return false
+}
+
+func (tl *TodoList) getListInTab(tab Tab) []Todo {
+	switch tab {
+	case ARCHIVE:
+		return tl.archs
+	case TODO:
+		return tl.todos
+	}
+	return []Todo{}
 }
 
 func (t *Todo) tolimitStr(limit int) string {


### PR DESCRIPTION
- ArchiveおよびTodoの描画用の文字列配列を返すAPI
- Todolistの構造体にArchive用とTodo用の構造体Todoのリストをもたせるように変更
- Todolist構造体の変更に伴い、ReadCSVを修正
- isArchiveを処理していなかったのを修正
